### PR TITLE
Remove Blog link from navbar

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,6 @@ import styles from './Header.module.css'
 
 const NAV_LINKS = [
   { label: 'Docs', href: 'https://agentship.readthedocs.io/' },
-  { label: 'Blog', href: 'https://github.com/harshuljain13/ship-ai-agents/tree/main/ai/articles' },
   { label: 'Community', href: '#community' },
 ]
 


### PR DESCRIPTION
Fixes #1

Removed the Blog link from the navigation bar since there is no active blog yet.

## Changes
- Removed Blog entry from `NAV_LINKS` array in `src/components/Header.tsx`
- Build verified and passing

Generated with [Claude Code](https://claude.ai/code)